### PR TITLE
JS Code to extract latitude and longitude from mapbox api based on zip code

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -2,6 +2,7 @@ var zipCodeEl = document.getElementById("zipcode");
 
 function getZipCoordinates() {
     var userZip = zipCodeEl.value.trim();
+    var mapboxUrl = "https://api.mapbox.com/geocoding/v5/mapbox.places/" + userZip + ".json?access_token=pk.eyJ1IjoiYWRhbWJhcnJvbiIsImEiOiJja2d2dm84aW4wMXA0MzBsODltNjZ5ZzFiIn0.W7Kpov0CjgFZQWXRaFlKzg"
 
     fetch("https://api.mapbox.com/geocoding/v5/mapbox.places/94043.json?access_token=pk.eyJ1IjoiYWRhbWJhcnJvbiIsImEiOiJja2d2dm84aW4wMXA0MzBsODltNjZ5ZzFiIn0.W7Kpov0CjgFZQWXRaFlKzg").then(function(response) {
         if (response.ok) {

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,10 +1,15 @@
+var zipCodeEl = document.getElementById("zipcode");
+
 function getZipCoordinates() {
+    var userZip = zipCodeEl.value.trim();
+
     fetch("https://api.mapbox.com/geocoding/v5/mapbox.places/94043.json?access_token=pk.eyJ1IjoiYWRhbWJhcnJvbiIsImEiOiJja2d2dm84aW4wMXA0MzBsODltNjZ5ZzFiIn0.W7Kpov0CjgFZQWXRaFlKzg").then(function(response) {
-        console.log(response);
         if (response.ok) {
             response.json().then(function(data) {
                 console.log(data);
             });
+        } else {
+
         };
     })
 }

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,0 +1,12 @@
+function getZipCoordinates() {
+    fetch("https://api.mapbox.com/geocoding/v5/mapbox.places/94043.json?access_token=pk.eyJ1IjoiYWRhbWJhcnJvbiIsImEiOiJja2d2dm84aW4wMXA0MzBsODltNjZ5ZzFiIn0.W7Kpov0CjgFZQWXRaFlKzg").then(function(response) {
+        console.log(response);
+        if (response.ok) {
+            response.json().then(function(data) {
+                console.log(data);
+            });
+        };
+    })
+}
+
+getZipCoordinates();

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,16 +1,26 @@
 var zipCodeEl = document.getElementById("zipcode");
 
 function getZipCoordinates() {
+    // will pull user zip from input field - likely need a search or submit button with listener
     var userZip = zipCodeEl.value.trim();
     var mapboxUrl = "https://api.mapbox.com/geocoding/v5/mapbox.places/" + userZip + ".json?access_token=pk.eyJ1IjoiYWRhbWJhcnJvbiIsImEiOiJja2d2dm84aW4wMXA0MzBsODltNjZ5ZzFiIn0.W7Kpov0CjgFZQWXRaFlKzg"
 
+    // fetch coordinates based on zip from map box. Can replace fill URL with 'mapboxUrl' variable when button is enabled
     fetch("https://api.mapbox.com/geocoding/v5/mapbox.places/94043.json?access_token=pk.eyJ1IjoiYWRhbWJhcnJvbiIsImEiOiJja2d2dm84aW4wMXA0MzBsODltNjZ5ZzFiIn0.W7Kpov0CjgFZQWXRaFlKzg").then(function(response) {
         if (response.ok) {
             response.json().then(function(data) {
                 console.log(data);
+
+                // define latitude from returned data
+                var latitude = data.features[0].center[1];
+
+                //define latitude from returned data
+                var longitude = data.features[0].center[0];
+
+                console.log(latitude, longitude);
             });
         } else {
-
+            // insert modal here with error message? (Had trouble getting this to work with Materialize)
         };
     })
 }

--- a/index.html
+++ b/index.html
@@ -106,6 +106,7 @@
   <footer class="footer">
 
   </footer>
+  <script src="./assets/js/script.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
- Currently, fetch() has hardcoded url with 94043 zip. I think we will need to add a "search" or "submit" button to the zip code input field and add a click listener to make the mapboxUrl variable work.

-console logs currently in place to show full data response and also to show returned latitude/longitude. We can remove these at the end

- Since we can't use alerts, I don't have anything in the else {} statement for the fetch. Will need to look into how to trigger a modal if response is not "ok".