### PR TITLE
Update script.js id references from "zipcode" to "textarea1" to match index.html

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,4 +1,4 @@
-var zipCodeEl = document.getElementById("zipcode");
+var zipCodeEl = document.getElementById("textarea1");
 
 // document.addEventListener('DOMContentLoaded', function () {
 //     var elems = document.querySelectorAll('select');
@@ -52,31 +52,12 @@ var btn = document.getElementById("btn")
 
 var click = btn.onclick = function () {
     // set item to local storage
-    var value = document.getElementById("zipcode").value;
+    var value = document.getElementById("textarea1").value;
     localStorage.setItem("zipcode", value)
     console.log(value)
     // retrieve from local storeage and append in zipcodeop
     document.getElementById("zipCodeOp").innerHTML = localStorage.getItem("zipcode")
 
 }
-
-
-//drop down distance menu
-document.addEventListener('DOMContentLoaded', function () {
-    var elems = document.querySelectorAll('select');
-    var instances = M.FormSelect.init(elems, options);
-});
-
-// Or with jQuery
-
-$(document).ready(function () {
-    $('select').formSelect();
-});
-
-
-
-
-
-getZipCoordinates();
 
 


### PR DESCRIPTION
-Id for textarea had been changed from 'zipcode' to 'textarea1'. I changed the references in script.js to 'textarea1' to match index.html so that local storage function works and so that var zipCodeEl gets the right element by id.

-Also deleted a block of duplicate code